### PR TITLE
Integrate Telegram Mini App: Add /miniapp command and mini_app.py for user interaction

### DIFF
--- a/mini_app.py
+++ b/mini_app.py
@@ -1,30 +1,36 @@
 """
-Scaffold for Telegram Mini App support.
-This module will provide a simple, user-friendly interface for users to input their location and receive current weather information via Telegram Mini Apps.
+Telegram Mini App integration for weather queries.
+This class provides a simple interface for the Telegram bot to use as a mini app.
 """
+from bot import get_weather
 
 class TelegramMiniApp:
     def __init__(self):
-        # Initialize mini app state, e.g., user session, UI elements
-        pass
+        self.last_location = None
+        self.last_weather = None
 
-    def get_user_location(self):
-        """
-        Placeholder for method to get user location input from the mini app UI.
-        """
-        pass
+    def set_location(self, location: str):
+        """Set the user's location for weather queries."""
+        self.last_location = location
+        return f"Location set to: {location}"
 
-    def fetch_weather(self, location):
-        """
-        Placeholder for method to fetch weather information for the given location.
-        """
-        pass
+    def fetch_weather(self):
+        """Fetch weather for the last set location using get_weather from bot.py."""
+        if not self.last_location:
+            return "No location set. Please set a location first."
+        self.last_weather = get_weather(self.last_location)
+        return self.last_weather
 
     def render_ui(self):
-        """
-        Placeholder for method to render the mini app UI.
-        Should be simple and easy to use.
-        """
-        pass
-
-# TODO: Integrate this module with the main bot logic and Telegram Mini App API.
+        """Return a simple text UI for the mini app (placeholder for real UI)."""
+        ui = "Telegram Weather Mini App\n"
+        if self.last_location:
+            ui += f"Current location: {self.last_location}\n"
+        else:
+            ui += "No location set.\n"
+        if self.last_weather:
+            ui += f"Weather: {self.last_weather}\n"
+        else:
+            ui += "No weather data.\n"
+        ui += "\nCommands:\n- set_location(<city>)\n- fetch_weather()\n- render_ui()\n"
+        return ui


### PR DESCRIPTION
This pull request completes the integration of the Telegram Mini App feature:

- Implements TelegramMiniApp in mini_app.py with set_location, fetch_weather, and render_ui methods.
- Updates bot.py to import and use TelegramMiniApp.
- Adds a /miniapp command to the bot for users to set location, fetch weather, and interact with the mini app interface.

This addresses issue #11 and enables users to access weather information through a simple mini app interface in Telegram.

## Summary by Sourcery

Integrate a stateful Telegram mini app into the weather bot to allow users to set a location, fetch weather data, and interact with a simple UI via a new /miniapp command.

New Features:
- Add TelegramMiniApp class with set_location, fetch_weather, and render_ui methods in mini_app.py
- Register /miniapp command in bot.py to handle mini app actions and display its UI

Enhancements:
- Update start command message to include instructions for the mini app interface