### PR TITLE
Fix circular import between bot.py and mini_app.py

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4,13 +4,12 @@ import requests
 from itertools import groupby
 from telegram import Update, Bot
 from telegram.ext import Updater, CommandHandler, CallbackContext
-from mini_app import TelegramMiniApp
 
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 OPENWEATHER_API_KEY = os.getenv("OPENWEATHER_API_KEY")
 
-# Instantiate the mini app
-mini_app = TelegramMiniApp()
+# Instantiate the mini app inside the function to avoid circular import
+mini_app = None
 
 def get_weather(city: str):
     if not OPENWEATHER_API_KEY:
@@ -75,6 +74,10 @@ def forecast_command(update: Update, context: CallbackContext):
     update.message.reply_text(result)
 
 def miniapp_command(update: Update, context: CallbackContext):
+    global mini_app
+    if mini_app is None:
+        from mini_app import TelegramMiniApp
+        mini_app = TelegramMiniApp()
     if not context.args:
         update.message.reply_text(mini_app.render_ui())
         return

--- a/mini_app.py
+++ b/mini_app.py
@@ -2,7 +2,6 @@
 Telegram Mini App integration for weather queries.
 This class provides a simple interface for the Telegram bot to use as a mini app.
 """
-from bot import get_weather
 
 class TelegramMiniApp:
     def __init__(self):
@@ -18,6 +17,7 @@ class TelegramMiniApp:
         """Fetch weather for the last set location using get_weather from bot.py."""
         if not self.last_location:
             return "No location set. Please set a location first."
+        from bot import get_weather  # moved import here to break circular import
         self.last_weather = get_weather(self.last_location)
         return self.last_weather
 


### PR DESCRIPTION
This PR resolves issue #16 by refactoring the import statements in bot.py and mini_app.py. The import of TelegramMiniApp is now inside the miniapp_command function in bot.py, and the import of get_weather is now inside the fetch_weather method in mini_app.py. This breaks the circular dependency and allows tests to run successfully.

## Summary by Sourcery

Refactor import placement to break circular dependency between bot.py and mini_app.py by lazy-loading modules

Bug Fixes:
- Resolve circular import errors by moving imports inside functions

Enhancements:
- Lazy-instantiate TelegramMiniApp in miniapp_command by initializing mini_app to None and importing within the handler
- Move import of get_weather into TelegramMiniApp.fetch_weather to defer module loading